### PR TITLE
Update CreateAction.php

### DIFF
--- a/packages/tables/src/Actions/CreateAction.php
+++ b/packages/tables/src/Actions/CreateAction.php
@@ -86,7 +86,7 @@ class CreateAction extends Action
 
                 return;
             }
-
+            $this->record(null); // Ensure the record is reset to solve issue #3070
             $this->success();
         });
     }


### PR DESCRIPTION
Ensure the relation manger record is reset to null after creation to avoid changing the previous record when creating a new one.
Fixes #3070
Fixes #3307